### PR TITLE
Add pytests for dagster code location load status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugi
 # Install pytest & testinfra
 RUN /usr/local/bin/pip3 install pytest-testinfra fastapi[all]
 
+# Install dagster & dagster_graphql
+RUN /usr/local/bin/pip3 install dagster dagster_graphql
+
 RUN mkdir /healthcheck_api
 COPY healthcheck_api /healthcheck_api
 RUN mkdir /tests

--- a/healthcheck_api/main.py
+++ b/healthcheck_api/main.py
@@ -11,7 +11,7 @@ async def root(test_name: str):
             "/usr/local/bin/python3",
             "-m",
             "pytest",
-            "-v",
+            "-vv",
             "--show-capture=stdout",
             f"{test_name or ''}",
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ python = "^3.11"
 pytest = "^7.4.4"
 pytest-testinfra = {version = "^10.0.0", extras = ["docker"]}
 fastapi = {version = "^0.109.0", extras = ["all"]}
-
+dagster = "^1.9.9"
+dagster-graphql = "^1.9.9"
 
 [tool.poetry.group.dev.dependencies]
 pyright = "^1.1.345"

--- a/tests/test_dagster.py
+++ b/tests/test_dagster.py
@@ -1,8 +1,69 @@
+import os
+import pytest  # type: ignore[import-not-found]
+import testinfra  # type: ignore[import-not-found]
 
-import DagsterGraphQLPythonClient
 
-def test_dagster_loaded_modules():
-    dagster_client = DagsterGraphQLPythonClient.Client("http://localhost:3000/graphql")
-    result = dagster_client.execute("query { __schema { types { name } } }")
-    assert result["data"]["__schema"]["types"] is not None
+from dagster_graphql import DagsterGraphQLClient
+from typing import Any, Dict, List, Literal, Tuple
 
+
+dagster_env: Literal["dev", "qa", "production"] = os.environ.get(  # type: ignore  # noqa: PGH003
+    "DAGSTER_ENVIRONMENT", "dev"
+)
+
+# define prod and dev dagster urls
+dagster_url_map = {
+        "dev": ["dagster_webserver", 3000],
+        "qa": ["dagster-webserver", 3000],
+        "production": ["dagster-webserver", 3000],
+}
+
+# GQL Query for code_location status
+location_status_query = ("""
+query LocationStatusesQuery {
+  workspaceOrError {
+                ... on Workspace {
+      locationEntries {
+        ... on WorkspaceLocationEntry {
+          id
+          loadStatus
+          locationOrLoadError {
+            __typename
+          }
+        }
+      }
+    }
+  }
+}
+""")
+
+def parseLocationEntries(location_entries: List[Dict[str, Any]]) -> Tuple[List[str], List[str]]:
+  i=0
+  errored=[]
+  loaded=[]
+  for location in location_entries:
+    i+=1
+    locationOrError = location["locationOrLoadError"]
+    typeName = locationOrError["__typename"]
+    loadStatus = location["loadStatus"]
+    if typeName == "PythonError" or loadStatus != "LOADED":
+      errored.append(location["id"])
+    elif typeName == "RepositoryLocation" and loadStatus == "LOADED":
+      loaded.append(location["id"])
+  return errored, loaded
+
+def get_dagster_client(
+    dagster_env: Literal["dev", "qa", "production"]
+):
+    # get the correct dagster url for the current environment
+    dagster_url, port = dagster_url_map[dagster_env]
+    dagster_client = DagsterGraphQLClient(hostname=dagster_url, port_number=port)
+    return dagster_client
+
+# monitoring Dagster code_location load status
+def test_dagster_code_locations():
+    dagster_client = get_dagster_client(dagster_env)
+    location_status = dagster_client._execute(location_status_query)
+    location_entries = dict(location_status["workspaceOrError"])["locationEntries"]
+    errored, loaded = parseLocationEntries(location_entries)
+    assert errored == []


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6223

### Description (What does it do?)
This PR adds tests to check if any of our dagster code locations have errored on load.
They are implemented under the new /healthchecks/test_dagster endpoint.

Added test logic and helper functions to test dagster code location load status.
Added -vv flag to the pytest call for more verbose results.
Added dagster and dagster gql libraries to the pyproject and dockerfile.